### PR TITLE
Enable guide-extension to serve grass files

### DIFF
--- a/guide-extension/readme.adoc
+++ b/guide-extension/readme.adoc
@@ -51,11 +51,10 @@ This is the core idea of exposing static web resources under the mountpoint.
 [source,java]
 ----
 @GET
-@Path("{file:(?i).+\\.(png|jpg|jpeg|svg|gif|html?|js|css|txt)}")
+@Path("{file:(?i).+\\.(png|jpg|jpeg|svg|gif|html?|js|css|txt|grass)}")
 public Response file(@PathParam("file") String file) throws IOException {
     InputStream fileStream = findFileStream(file);
     if (fileStream == null) return Response.status(Response.Status.NOT_FOUND).build();
     else return Response.ok(fileStream, mediaType(file)).build();
 }
 ----
-

--- a/guide-extension/src/main/java/extension/web/StaticWebResource.java
+++ b/guide-extension/src/main/java/extension/web/StaticWebResource.java
@@ -31,9 +31,9 @@ public class StaticWebResource {
         if (path == null) path = "guides";
         File file = new File(path);
 		this.directory = file.exists() ? file : null;
-		
+
 	}
-	
+
     @Path("/")
     @Produces("text/html")
     @GET
@@ -44,7 +44,7 @@ public class StaticWebResource {
     static Map<String,File> resources = new ConcurrentHashMap<>();
 
     @GET
-    @Path("{file:(?i).+\\.(png|jpg|jpeg|svg|gif|html?|js|css|txt)}")
+    @Path("{file:(?i).+\\.(png|jpg|jpeg|svg|gif|html?|js|css|txt|grass)}")
     public Response file(@PathParam("file") String file) throws IOException {
         InputStream fileStream = findFileStream(file);
         if (fileStream == null) return Response.status(Response.Status.NOT_FOUND).build();


### PR DESCRIPTION
Since there's no supported builtin way of loading a local grass file (see neo4j/neo4j-browser#171), hosting grass files using the guide-extension would be handy.